### PR TITLE
ci: validate poetry.lock & qdrant service name (aurora-qdrant)

### DIFF
--- a/CHANGELOG/ci-lockfile-qdrant-fix.md
+++ b/CHANGELOG/ci-lockfile-qdrant-fix.md
@@ -1,0 +1,7 @@
+ci: validate poetry.lock and normalize Qdrant service name (aurora-qdrant)
+
+This small changelog accompanies the CI changes to:
+- add Poetry lockfile validation to workflows
+- standardize Qdrant docker service name to `aurora-qdrant`
+
+See files: .github/workflows/tests.yml, .github/workflows/crawler-tests.yml


### PR DESCRIPTION
Adds CI lockfile validation and normalizes qdrant service name in workflows. See CHANGELOG/ci-lockfile-qdrant-fix.md.