### PR TITLE
CI: Crawler Smoke — canário do módulo RN contacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ aurora-knowledge-base/
 # Relatórios de Análise de Segurança
 secrets_*.md
 secrets_*.txt
+
+# Aurora Crawler POC outputs
+data/outputs/

--- a/aurora_platform/modules/crawler/rn_contacts/__init__.py
+++ b/aurora_platform/modules/crawler/rn_contacts/__init__.py
@@ -1,0 +1,11 @@
+"""RN contacts crawler package (POC).
+Lightweight POC code for extracting official contacts from RN / gov.br sites.
+"""
+
+__all__ = [
+    "config",
+    "extract",
+    "pdf",
+    "output",
+    "runner",
+]

--- a/aurora_platform/modules/crawler/rn_contacts/config.py
+++ b/aurora_platform/modules/crawler/rn_contacts/config.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass, field  # noqa: F401 (reservado p/ fut.)
+from typing import List, Pattern
+import re
+
+USER_AGENT = "AuroraCrawler/1.0 (+https://aurora.example)"
+
+# prioriza RN; permite gov.br (estadual/municipal)
+ALLOWED_SUFFIXES = [".rn.gov.br", ".gov.br"]
+
+# por padrão, não exportar emails pessoais (pode ser liberado por flag)
+DISALLOW_PERSONAL = True
+
+SEEDS: List[str] = [
+    "https://www.rn.gov.br/",
+    "https://www.natal.rn.gov.br/",
+    "https://www.mossoro.rn.gov.br/",
+    "https://www.parnamirim.rn.gov.br/",
+    "https://www.caico.rn.gov.br/",
+    "https://www.curraisnovos.rn.gov.br/",
+]
+
+KEYWORDS_BY_CATEGORY = {
+    "licitacoes": ["licit", "pregao", "compras", "suprimentos", "contrat", "edital"],
+    "administracao": ["administra", "planej", "finan", "meio ambiente", "semurb", "gestao"],
+    "rh": ["recursos humanos", "rh", "pessoal"],
+    "secretariado": ["secretaria", "secretário", "secretaria adjunta", "gabinete", "diretoria", "diretor"],
+    "consorcios": ["consórcio", "consorcio", "intermunicipal"],
+}
+
+EMAIL_RE: Pattern = re.compile(
+    r"(?P<email>[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,})",
+    re.IGNORECASE,
+)
+
+NAME_HINT_RE: Pattern = re.compile(
+    r"(?:(?:Secretári[oa]|Diretor[ae]?|Gerent[ea]|Chefe|Coordenador[ae]?|Pregoeir[oa]))[:\s-]+"
+    r"(?P<nome>[A-ZÁÉÍÓÚÂÊÔÃÕÇ][A-Za-zÀ-ÖØ-öø-ÿ'`´^~ ]{5,80})"
+)

--- a/aurora_platform/modules/crawler/rn_contacts/extract.py
+++ b/aurora_platform/modules/crawler/rn_contacts/extract.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+from typing import Dict, Any, Iterable, Tuple
+from .config import EMAIL_RE, NAME_HINT_RE, KEYWORDS_BY_CATEGORY, ALLOWED_SUFFIXES, DISALLOW_PERSONAL
+
+PERSONAL_PROVIDERS = ("gmail.com", "hotmail.com", "outlook.com", "yahoo.com", "icloud.com")
+
+
+def is_official(email: str) -> bool:
+    dom = email.split("@")[-1].lower()
+    if dom.endswith(tuple(s.lstrip(".") for s in ALLOWED_SUFFIXES)):
+        return True
+    if dom in PERSONAL_PROVIDERS:
+        return False
+    # outros domínios privados -> não-oficial
+    return False
+
+
+def should_keep(email: str, allow_non_official: bool) -> bool:
+    return is_official(email) or allow_non_official
+
+
+def guess_category_role(text_blob: str) -> Tuple[str|None, str|None]:
+    low = text_blob.lower()
+    for cat, keys in KEYWORDS_BY_CATEGORY.items():
+        if any(k in low for k in keys):
+            # role_hint simplista: primeira palavra-chave que bate
+            return cat, next((k for k in keys if k in low), None)
+    return None, None
+
+
+def near_name(text_blob: str) -> str|None:
+    m = NAME_HINT_RE.search(text_blob)
+    return m.group("nome").strip() if m else None
+
+
+def extract_from_text(url: str, title: str|None, text: str, *, allow_non_official: bool=False) -> Iterable[Dict[str, Any]]:
+    hits = []
+    for m in EMAIL_RE.finditer(text or ""):
+        email = m.group("email")
+        if not should_keep(email, allow_non_official):
+            continue
+        name = near_name(text[max(0, m.start()-400): m.end()+400])  # janela em torno do e-mail
+        category, role_hint = guess_category_role(text[max(0, m.start()-1000): m.end()+1000])
+        org_hint = title or ""
+        official = is_official(email)
+        confidence = "high" if official else "low"
+        hits.append({
+            "email": email,
+            "name": name,
+            "category": category,
+            "role_hint": role_hint,
+            "official": official,
+            "confidence": confidence,
+            "page_url": url,
+            "page_title": title,
+        })
+    return hits

--- a/aurora_platform/modules/crawler/rn_contacts/output.py
+++ b/aurora_platform/modules/crawler/rn_contacts/output.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+from typing import Dict, Any, Iterable, List
+import csv, json, os, hashlib, datetime as dt
+
+def ensure_dir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+def sha1(s: str) -> str:
+    return hashlib.sha1(s.encode("utf-8", "ignore")).hexdigest()
+
+def dedup(records: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    seen = set()
+    out = []
+    for r in records:
+        key = (r.get("email","" ).lower(), r.get("page_url",""))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(r)
+    return out
+
+def write_outputs(base_dir: str, records: List[Dict[str, Any]], meta: Dict[str, Any]) -> Dict[str, str]:
+    ensure_dir(base_dir)
+    ts = dt.datetime.utcnow().isoformat()
+    meta = dict(meta, written_at=ts, total=len(records))
+
+    jsonl_path = os.path.join(base_dir, "contacts.jsonl")
+    csv_path = os.path.join(base_dir, "contacts.csv")
+    meta_path = os.path.join(base_dir, "manifest.json")
+
+    with open(jsonl_path, "w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    if records:
+        headers = sorted({k for r in records for k in r.keys()})
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=headers)
+            w.writeheader()
+            w.writerows(records)
+
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(meta, f, ensure_ascii=False, indent=2)
+
+    return {"jsonl": jsonl_path, "csv": csv_path, "manifest": meta_path}

--- a/aurora_platform/modules/crawler/rn_contacts/pdf.py
+++ b/aurora_platform/modules/crawler/rn_contacts/pdf.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+from typing import Optional
+from pypdf import PdfReader
+from io import BytesIO
+
+def pdf_to_text(data: bytes) -> Optional[str]:
+    try:
+        reader = PdfReader(BytesIO(data))
+        chunks = []
+        for page in reader.pages:
+            txt = page.extract_text() or ""
+            if txt.strip():
+                chunks.append(txt)
+        return "\n\n".join(chunks) if chunks else None
+    except Exception:
+        return None

--- a/aurora_platform/modules/crawler/rn_contacts/runner.py
+++ b/aurora_platform/modules/crawler/rn_contacts/runner.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+import asyncio, re, time, os, json
+from typing import Set, Dict, Any, List, Tuple
+import httpx
+from selectolax.parser import HTMLParser
+from urllib.parse import urljoin, urlparse
+from urllib import robotparser
+from .config import USER_AGENT, SEEDS, ALLOWED_SUFFIXES
+from .extract import extract_from_text
+from .pdf import pdf_to_text
+from .output import write_outputs, dedup
+import datetime as dt
+
+PDF_LINK_RE = re.compile(r"\.pdf($|\?)", re.IGNORECASE)
+
+def allow_url(u: str) -> bool:
+    host = urlparse(u).netloc.lower()
+    return host.endswith(tuple(s.lstrip(".") for s in ALLOWED_SUFFIXES))
+
+async def fetch_text(client: httpx.AsyncClient, url: str):
+    r = await client.get(url, timeout=15.0, follow_redirects=True)
+    r.raise_for_status()
+    ctype = r.headers.get("content-type","" ).lower()
+    if "pdf" in ctype or PDF_LINK_RE.search(url):
+        return "pdf", r.content
+    return "html", r.content
+
+def extract_links(base_url: str, html: bytes):
+    doc = HTMLParser(html.decode("utf-8", "ignore"))
+    title = (doc.css_first("title").text(strip=True) if doc.css_first("title") else None)
+    links = []
+    for a in doc.css("a[href]"):
+        href = a.attributes.get("href")
+        if not href:
+            continue
+        url = urljoin(base_url, href)
+        if url.startswith("mailto:"):
+            links.append(url)
+        elif allow_url(url):
+            links.append(url)
+    text = doc.text(separator=" ", strip=True)[:200000]
+    return title, links, text
+
+def can_fetch(robots: robotparser.RobotFileParser, url: str) -> bool:
+    try:
+        return robots.can_fetch(USER_AGENT, url)
+    except Exception:
+        return True
+
+async def crawl(*, seeds: List[str], out_dir: str, max_pages: int = 250, allow_non_official: bool=False) -> Dict[str, Any]:
+    visited: Set[str] = set()
+    queue: List[str] = [u for u in seeds if allow_url(u)]
+    found: List[Dict[str, Any]] = []
+
+    robots_cache: Dict[str, robotparser.RobotFileParser] = {}
+    per_host_last = {}
+
+    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, http2=True) as client:
+        while queue and len(visited) < max_pages:
+            url = queue.pop(0)
+            if url in visited:
+                continue
+            visited.add(url)
+
+            host = urlparse(url).netloc.lower()
+            # rate limit por host (mín. 0.7s)
+            last = per_host_last.get(host, 0.0)
+            delta = time.monotonic() - last
+            if delta < 0.7:
+                await asyncio.sleep(0.7 - delta)
+
+            # robots.txt
+            if host not in robots_cache:
+                rp = robotparser.RobotFileParser()
+                rp.set_url(f"https://{host}/robots.txt")
+                try:
+                    rp.read()
+                except Exception:
+                    pass
+                robots_cache[host] = rp
+            if not can_fetch(robots_cache[host], url):
+                continue
+
+            try:
+                kind, body = await fetch_text(client, url)
+            except Exception:
+                continue
+
+            if kind == "html":
+                title, links, text = extract_links(url, body)
+                # extrair emails do HTML
+                found.extend(extract_from_text(url, title, text, allow_non_official=allow_non_official))
+                # extrair mailto imediatos
+                for l in links:
+                    if l.startswith("mailto:"):
+                        email = l.split("mailto:",1)[1]
+                        found.extend(extract_from_text(url, title, email, allow_non_official=allow_non_official))
+                # enfileirar novos links
+                for l in links:
+                    if l.startswith("http"):
+                        queue.append(l)
+            else:  # pdf
+                text = pdf_to_text(body or b"")
+                if text:
+                    found.extend(extract_from_text(url, None, text, allow_non_official=allow_non_official))
+
+            per_host_last[host] = time.monotonic()
+
+    # dedup + gravação
+    records = dedup(found)
+    stamp = dt.datetime.utcnow().strftime("%Y%m%d-%H%M")
+    out_base = os.path.join(out_dir, f"rn_contacts_{stamp}")
+    paths = write_outputs(out_base, records, {
+        "version": "rn-contacts-0.1",
+        "seeds": seeds,
+        "max_pages": max_pages,
+        "allow_non_official": allow_non_official,
+        "user_agent": USER_AGENT,
+    })
+    return {"count": len(records), "paths": paths, "visited": len(visited)}
+
+if __name__ == "__main__":
+    import argparse
+    ap = argparse.ArgumentParser(description="RN contacts crawler (POC)")
+    ap.add_argument("--out", default="data/outputs/rn_contacts", help="output directory")
+    ap.add_argument("--max-pages", type=int, default=250)
+    ap.add_argument("--allow-non-official", action="store_true", help="include non-gov emails")
+    args = ap.parse_args()
+    res = asyncio.run(crawl(seeds=SEEDS, out_dir=args.out, max_pages=args.max_pages, allow_non_official=args.allow_non_official))
+    print(json.dumps(res, ensure_ascii=False))

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,3 +144,7 @@ uvicorn==0.29.0 ; python_version >= "3.11" and python_version < "4.0"
 validators==0.35.0 ; python_version >= "3.11" and python_version < "4.0"
 websockets==15.0.1 ; python_version >= "3.11" and python_version < "4.0"
 zstandard==0.23.0 ; python_version >= "3.11" and python_version < "4.0"
+httpx[http2]>=0.27
+selectolax>=0.3.12
+tldextract>=5.1
+pypdf>=4.0

--- a/tests/modules/crawler/test_rn_contacts.py
+++ b/tests/modules/crawler/test_rn_contacts.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+def test_extract_basic_email_and_name():
+    from aurora_platform.modules.crawler.rn_contacts.extract import extract_from_text
+
+    html = "Secretária: Maria Lima — contato: compras@prefeitura.rn.gov.br"
+    results = list(extract_from_text("https://prefeitura.rn.gov.br/x", "Compras", html))
+    assert len(results) >= 1
+    r = results[0]
+    assert "email" in r and r["email"].endswith("@prefeitura.rn.gov.br")
+    assert "name" in r and "Maria" in r["name"]
+
+
+def test_official_domain():
+    from aurora_platform.modules.crawler.rn_contacts.extract import is_official
+
+    assert is_official("user@secretaria.rn.gov.br")
+    assert is_official("foo@org.gov.br")
+    assert not is_official("joe@gmail.com")


### PR DESCRIPTION
Adiciona workflow leve que executa apenas o teste canário tests/modules/crawler/test_rn_contacts.py em PRs que tocam o crawler. Usa Python 3.11, instala deps via requirements/pyproject, e força PYTHONPATH=repo root com TESTING=1.